### PR TITLE
Changed get_lines to generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ from gcodeparser import GcodeParser
 with open('my_gcode.gcode', 'r') as f:
   gcode = f.read()
 
-GcodeParser(gcode).lines    # get parsed gcode lines
+for line in GcodeParser(gcode).lines  : # call to generator
+  print(line) # get parsed gcode line
 ```
 
 ## Include Comments
@@ -68,32 +69,34 @@ from gcodeparser import GcodeParser
 
 with open('3DBenchy.gcode', 'r') as f:
     gcode = f.read()
+
 parsed_gcode = GcodeParser(gcode)
-parsed_gcode.lines
+
+for line in parsed_gcode.lines  :
+  print(line)
 ```
 
 _output:_
 
 ```py
-[GcodeLine(command=('G', 10), params={'P': 0, 'R': 0, 'S': 0}, comment='sets the standby temperature'),
- GcodeLine(command=('G', 29), params={'S': 1}, comment=''),
- GcodeLine(command=('T', 0), params={}, comment=''),
- GcodeLine(command=('G', 21), params={}, comment='set units to millimeters'),
- GcodeLine(command=('G', 90), params={}, comment='use absolute coordinates'),
- GcodeLine(command=('M', 83), params={}, comment='use relative distances for extrusion'),
- GcodeLine(command=('G', 1), params={'E': -0.6, 'F': 3600.0}, comment=''),
- GcodeLine(command=('G', 1), params={'Z': 0.45, 'F': 7800.0}, comment=''),
- GcodeLine(command=('G', 1), params={'Z': 2.35}, comment=''),
- GcodeLine(command=('G', 1), params={'X': 119.575, 'Y': 89.986}, comment=''),
- GcodeLine(command=('G', 1), params={'Z': 0.45}, comment=''),
- GcodeLine(command=('G', 1), params={'E': 0.6, 'F': 3600.0}, comment=''),
- GcodeLine(command=('G', 1), params={'F': 1800.0}, comment=''),
- GcodeLine(command=('G', 1), params={'X': 120.774, 'Y': 88.783, 'E': 0.17459}, comment=''),
- GcodeLine(command=('G', 1), params={'X': 121.692, 'Y': 88.145, 'E': 0.11492}, comment=''),
- GcodeLine(command=('G', 1), params={'X': 122.7, 'Y': 87.638, 'E': 0.11596}, comment=''),
- GcodeLine(command=('G', 1), params={'X': 123.742, 'Y': 87.285, 'E': 0.11317}, comment=''),
+GcodeLine(command=('G', 10), params={'P': 0, 'R': 0, 'S': 0}, comment='sets the standby temperature')
+ GcodeLine(command=('G', 29), params={'S': 1}, comment='')
+ GcodeLine(command=('T', 0), params={}, comment='')
+ GcodeLine(command=('G', 21), params={}, comment='set units to millimeters')
+ GcodeLine(command=('G', 90), params={}, comment='use absolute coordinates')
+ GcodeLine(command=('M', 83), params={}, comment='use relative distances for extrusion')
+ GcodeLine(command=('G', 1), params={'E': -0.6, 'F': 3600.0}, comment='')
+ GcodeLine(command=('G', 1), params={'Z': 0.45, 'F': 7800.0}, comment='')
+ GcodeLine(command=('G', 1), params={'Z': 2.35}, comment='')
+ GcodeLine(command=('G', 1), params={'X': 119.575, 'Y': 89.986}, comment='')
+ GcodeLine(command=('G', 1), params={'Z': 0.45}, comment='')
+ GcodeLine(command=('G', 1), params={'E': 0.6, 'F': 3600.0}, comment='')
+ GcodeLine(command=('G', 1), params={'F': 1800.0}, comment='')
+ GcodeLine(command=('G', 1), params={'X': 120.774, 'Y': 88.783, 'E': 0.17459}, comment='')
+ GcodeLine(command=('G', 1), params={'X': 121.692, 'Y': 88.145, 'E': 0.11492}, comment='')
+ GcodeLine(command=('G', 1), params={'X': 122.7, 'Y': 87.638, 'E': 0.11596}, comment='')
+ GcodeLine(command=('G', 1), params={'X': 123.742, 'Y': 87.285, 'E': 0.11317}, comment='')
  ...
-]
 ```
 
 ## Convert Command Tuple to String
@@ -142,4 +145,14 @@ line.delete_param('X')
 
 ## Converting to DataFrames
 
-If for whatever reason you want to convert your list of `GcodeLine` objects into a pandas dataframe, simply use `pd.DataFrame(GcodeParser(gcode).lines)`
+If for whatever reason you want to convert your list of `GcodeLine` objects into a pandas dataframe, simply use :
+
+```python
+all_lines = []
+
+for line in GcodeParser(gcode).lines :
+
+  all_lines.append(line)
+
+pd.DataFrame(all_lines)
+```

--- a/gcodeparser/gcode_parser.py
+++ b/gcodeparser/gcode_parser.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Tuple, Union
+from typing import Generator, Dict, Tuple, Union
 from dataclasses import dataclass
 import re
 from .commands import Commands
@@ -11,18 +11,20 @@ class GcodeLine:
     comment: str
 
     def __post_init__(self):
-        if self.command[0] == 'G' and self.command[1] in (0, 1, 2, 3):
+        if self.command[0] == "G" and self.command[1] in (0, 1, 2, 3):
             self.type = Commands.MOVE
-        elif self.command[0] == ';':
+        elif self.command[0] == ";":
             self.type = Commands.COMMENT
-        elif self.command[0] == 'T':
+        elif self.command[0] == "T":
             self.type = Commands.TOOLCHANGE
         else:
             self.type = Commands.OTHER
 
     @property
     def command_str(self):
-        return f"{self.command[0]}{self.command[1] if self.command[1] is not None else ''}"
+        return (
+            f"{self.command[0]}{self.command[1] if self.command[1] is not None else ''}"
+        )
 
     def get_param(self, param: str, return_type=None, default=None):
         """
@@ -61,9 +63,11 @@ class GcodeLine:
                 return ""
             return value
 
-        params = " ".join(f"{param}{param_value(param)}" for param in self.params.keys())
-        comment = f"; {self.comment}" if self.comment != '' else ""
-        if command == ';':
+        params = " ".join(
+            f"{param}{param_value(param)}" for param in self.params.keys()
+        )
+        comment = f"; {self.comment}" if self.comment != "" else ""
+        if command == ";":
             return comment
         return f"{command} {params} {comment}".strip()
 
@@ -71,14 +75,14 @@ class GcodeLine:
 class GcodeParser:
     def __init__(self, gcode: str, include_comments=False):
         self.gcode = gcode
-        self.lines: List[GcodeLine] = get_lines(self.gcode, include_comments)
+        self.lines: Generator[GcodeLine] = get_lines(self.gcode, include_comments)
         self.include_comments = include_comments
 
 
 def get_lines(gcode, include_comments=False):
     regex = r'(?!; *.+)(G|M|T|g|m|t)(\d+)(([ \t]*(?!G|M|g|m)\w(".*"|([-\d\.]*)))*)[ \t]*(;[ \t]*(.*))?|;[ \t]*(.+)'
     regex_lines = re.findall(regex, gcode)
-    lines = []
+
     for line in regex_lines:
         if line[0]:
             command = (line[0].upper(), int(line[1]))
@@ -86,29 +90,26 @@ def get_lines(gcode, include_comments=False):
             params = split_params(line[2])
 
         elif include_comments:
-            command = (';', None)
+            command = (";", None)
             comment = line[-1]
             params = {}
 
         else:
             continue
 
-        lines.append(
-            GcodeLine(
-                command=command,
-                params=params,
-                comment=comment.strip(),
-            ))
-
-    return lines
+        yield GcodeLine(
+            command=command,
+            params=params,
+            comment=comment.strip(),
+        )
 
 
 def element_type(element: str):
     if re.search(r'"', element):
         return str
-    if re.search(r'\..*\.', element):
+    if re.search(r"\..*\.", element):
         return str
-    if re.search(r'[+-]?\d*\.\d+', element):
+    if re.search(r"[+-]?\d*\.\d+", element):
         return float
     return int
 
@@ -118,7 +119,7 @@ def split_params(line):
     elements = re.findall(regex, line)
     params = {}
     for element in elements:
-        if element[1] == '':
+        if element[1] == "":
             params[element[0].upper()] = True
             continue
         params[element[0].upper()] = element_type(element[1])(element[1])
@@ -126,8 +127,8 @@ def split_params(line):
     return params
 
 
-if __name__ == '__main__':
-    with open('3DBenchy.gcode', 'r') as f:
+if __name__ == "__main__":
+    with open("3DBenchy.gcode", "r") as f:
         gcode = f.read()
     parsed_gcode = GcodeParser(gcode)
     pass

--- a/main.py
+++ b/main.py
@@ -1,7 +1,10 @@
 from gcodeparser import GcodeParser
 
-if __name__ == '__main__':
-    with open('3DBenchy.gcode', 'r') as f:
+if __name__ == "__main__":
+    with open("3DBenchy.gcode", "r") as f:
         gcode = f.read()
+
     parsed_gcode = GcodeParser(gcode)
-    pass
+
+    for line in parsed_gcode.lines:
+        print(line)

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ setup(
     version="0.1.1",
     include_package_data=True,
     packages=find_packages(),
-
-    install_requires=[
-    ],
-
+    install_requires=[],
     author="Andy Everitt",
     author_email="andreweveritt@e3d-online.com",
     description="Python gcode parser",

--- a/test/test_element_type.py
+++ b/test/test_element_type.py
@@ -4,31 +4,31 @@ from gcodeparser.gcode_parser import (
 
 
 def test_element_type_int():
-    assert element_type('109321') == int
+    assert element_type("109321") == int
 
 
 def test_element_type_neg_int():
-    assert element_type('-109321') == int
+    assert element_type("-109321") == int
 
 
 def test_element_type_float():
-    assert element_type('109321.0') == float
+    assert element_type("109321.0") == float
 
 
 def test_element_type_float2():
-    assert element_type('109321.012345') == float
+    assert element_type("109321.012345") == float
 
 
 def test_element_type_neg_float():
-    assert element_type('-1.0') == float
+    assert element_type("-1.0") == float
 
 
 def test_element_type_neg_float2():
-    assert element_type('-1.013456') == float
+    assert element_type("-1.013456") == float
 
 
 def test_element_type_str():
-    assert element_type('192.168.0.1') == str
+    assert element_type("192.168.0.1") == str
 
 
 def test_element_type_str2():

--- a/test/test_gcode_line.py
+++ b/test/test_gcode_line.py
@@ -10,62 +10,62 @@ from gcodeparser.commands import Commands
 
 def test_post_init_move():
     line = GcodeLine(
-        command=('G', 1),
-        params={'X': 10, 'Y': 20},
-        comment='this is a comment',
+        command=("G", 1),
+        params={"X": 10, "Y": 20},
+        comment="this is a comment",
     )
     assert line.type == Commands.MOVE
 
 
 def test_post_init_toolchange():
     line = GcodeLine(
-        command=('T', 1),
+        command=("T", 1),
         params={},
-        comment='this is a comment',
+        comment="this is a comment",
     )
     assert line.type == Commands.TOOLCHANGE
 
 
 def test_post_init_other():
     line = GcodeLine(
-        command=('G', 91),
-        params={'X': 10, 'Y': 20},
-        comment='this is a comment',
+        command=("G", 91),
+        params={"X": 10, "Y": 20},
+        comment="this is a comment",
     )
     assert line.type == Commands.OTHER
 
 
 def test_command_str():
     line = GcodeLine(
-        command=('G', 91),
-        params={'X': 10, 'Y': 20},
-        comment='this is a comment',
+        command=("G", 91),
+        params={"X": 10, "Y": 20},
+        comment="this is a comment",
     )
-    assert line.command_str == 'G91'
+    assert line.command_str == "G91"
 
 
 def test_to_gcode():
     line = GcodeLine(
-        command=('G', 91),
-        params={'X': 10, 'Y': 20},
-        comment='this is a comment',
+        command=("G", 91),
+        params={"X": 10, "Y": 20},
+        comment="this is a comment",
     )
-    assert line.gcode_str == 'G91 X10 Y20 ; this is a comment'
+    assert line.gcode_str == "G91 X10 Y20 ; this is a comment"
 
 
 def test_flag_parameter_to_gcode():
     line = GcodeLine(
-        command=('G', 28),
-        params={'X': True},
-        comment='',
+        command=("G", 28),
+        params={"X": True},
+        comment="",
     )
-    assert line.gcode_str == 'G28 X'
+    assert line.gcode_str == "G28 X"
 
 
 def test_flag_parameter_2_to_gcode():
     line = GcodeLine(
-        command=('G', 28),
-        params={'X': True, 'Y': 1},
-        comment='',
+        command=("G", 28),
+        params={"X": True, "Y": 1},
+        comment="",
     )
-    assert line.gcode_str == 'G28 X Y1'
+    assert line.gcode_str == "G28 X Y1"

--- a/test/test_get_lines.py
+++ b/test/test_get_lines.py
@@ -10,114 +10,135 @@ from gcodeparser.commands import Commands
 
 def test_no_params():
     line = GcodeLine(
-        command=('G', 21),
+        command=("G", 21),
         params={},
-        comment='',
+        comment="",
     )
-    assert get_lines('G21')[0] == line
+    assert get_lines("G21")[0] == line
 
 
 def test_params():
     line = GcodeLine(
-        command=('G', 1),
-        params={'X': 10, 'Y': 20},
-        comment='',
+        command=("G", 1),
+        params={"X": 10, "Y": 20},
+        comment="",
     )
-    assert get_lines('G1 X10 Y20')[0] == line
+    assert get_lines("G1 X10 Y20")[0] == line
 
 
 def test_2_commands_line():
     line1 = GcodeLine(
-        command=('G', 91),
+        command=("G", 91),
         params={},
-        comment='',
+        comment="",
     )
     line2 = GcodeLine(
-        command=('G', 1),
-        params={'X': 10, 'Y': 20},
-        comment='',
+        command=("G", 1),
+        params={"X": 10, "Y": 20},
+        comment="",
     )
-    lines = get_lines('G91 G1 X10 Y20')
+    lines = get_lines("G91 G1 X10 Y20")
     assert lines[0] == line1
     assert lines[1] == line2
 
 
 def test_string_params():
     line = GcodeLine(
-        command=('M', 550),
-        params={'P': '"hostname"'},
-        comment='',
+        command=("M", 550),
+        params={"P": '"hostname"'},
+        comment="",
     )
     assert get_lines('M550 P"hostname"')[0] == line
 
 
 def test_ip_address_params():
     line = GcodeLine(
-        command=('M', 552),
-        params={'P': '192.168.0.1', 'S': 1},
-        comment='',
+        command=("M", 552),
+        params={"P": "192.168.0.1", "S": 1},
+        comment="",
     )
-    assert get_lines('M552 P192.168.0.1 S1')[0] == line
+    assert get_lines("M552 P192.168.0.1 S1")[0] == line
 
 
 def test_inline_comment():
     line = GcodeLine(
-        command=('G', 1),
-        params={'X': 10, 'Y': 20},
-        comment='this is a comment',
+        command=("G", 1),
+        params={"X": 10, "Y": 20},
+        comment="this is a comment",
     )
-    assert get_lines('G1 X10 Y20 ; this is a comment')[0] == line
-    assert get_lines('G1 X10 Y20 ;      this is a comment')[0] == line
-    assert get_lines('G1 X10 Y20 \t;     \t this is a comment')[0] == line
-    assert get_lines('G1 X10 Y20 \t;     \t this is a comment')[0] == line
+    assert get_lines("G1 X10 Y20 ; this is a comment")[0] == line
+    assert get_lines("G1 X10 Y20 ;      this is a comment")[0] == line
+    assert get_lines("G1 X10 Y20 \t;     \t this is a comment")[0] == line
+    assert get_lines("G1 X10 Y20 \t;     \t this is a comment")[0] == line
 
 
 def test_inline_comment2():
     line = GcodeLine(
-        command=('G', 1),
-        params={'X': 10, 'Y': 20},
-        comment='this is a comment ; with a dummy comment for bants',
+        command=("G", 1),
+        params={"X": 10, "Y": 20},
+        comment="this is a comment ; with a dummy comment for bants",
     )
-    assert get_lines('G1 X10 Y20 ; this is a comment ; with a dummy comment for bants')[0] == line
+    assert (
+        get_lines("G1 X10 Y20 ; this is a comment ; with a dummy comment for bants")[0]
+        == line
+    )
 
 
 def test_include_comment_true():
     line = GcodeLine(
-        command=(';', None),
+        command=(";", None),
         params={},
-        comment='this is a comment',
+        comment="this is a comment",
     )
-    assert get_lines('; this is a comment', include_comments=True)[0] == line
+    assert get_lines("; this is a comment", include_comments=True)[0] == line
 
 
 def test_include_comment_false():
-    assert len(get_lines('; this is a comment', include_comments=False)) == 0
+    assert len(get_lines("; this is a comment", include_comments=False)) == 0
 
 
 def test_multi_line():
     lines = [
         GcodeLine(
-            command=('G', 91),
+            command=("G", 91),
             params={},
-            comment='',
-        ), GcodeLine(
-            command=('G', 1),
-            params={'X': -10, 'Y': 20},
-            comment='inline comment',
-        ), GcodeLine(
-            command=('G', 1),
-            params={'Z': 0.5},
-            comment='',
-        ), GcodeLine(
-            command=('T', 1),
+            comment="",
+        ),
+        GcodeLine(
+            command=("G", 1),
+            params={"X": -10, "Y": 20},
+            comment="inline comment",
+        ),
+        GcodeLine(
+            command=("G", 1),
+            params={"Z": 0.5},
+            comment="",
+        ),
+        GcodeLine(
+            command=("T", 1),
             params={},
-            comment='',
-        ), GcodeLine(
-            command=('M', 350),
-            params={'T': 100},
-            comment='',
-        )]
-    assert get_lines('G91\nG1 X-10 Y20 ; inline comment\nG1 Z0.5\nT1\nM350 T100') == lines
-    assert get_lines('G91G1 X-10 Y20;inline comment\nG1 Z0.5\nT1M350 T100') == lines
-    assert get_lines(' \tG91\n\tG1\t  X-10 Y20 \t ;\t inline comment\nG1 Z0.5\nT1\nM350 T100') == lines
-    assert get_lines('G91\nG1 X-10 Y20 ; inline comment\n; comment to be excluded\nG1 Z0.5\nT1\nM350 T100', include_comments=False) == lines
+            comment="",
+        ),
+        GcodeLine(
+            command=("M", 350),
+            params={"T": 100},
+            comment="",
+        ),
+    ]
+    assert (
+        get_lines("G91\nG1 X-10 Y20 ; inline comment\nG1 Z0.5\nT1\nM350 T100") == lines
+    )
+    assert get_lines("G91G1 X-10 Y20;inline comment\nG1 Z0.5\nT1M350 T100") == lines
+    assert (
+        get_lines(
+            " \tG91\n\tG1\t  X-10 Y20 \t ;\t inline comment\nG1 Z0.5\nT1\nM350 T100"
+        )
+        == lines
+    )
+    assert (
+        get_lines(
+            "G91\nG1 X-10 Y20 ; inline comment\n; comment to be excluded\nG1 Z0.5\nT1\nM350 T100",
+            include_comments=False,
+        )
+        == lines
+    )

--- a/test/test_split_params.py
+++ b/test/test_split_params.py
@@ -9,45 +9,62 @@ from gcodeparser.commands import Commands
 
 
 def test_split_int_params():
-    assert split_params(' P0 S1 X10') == {'P': 0, 'S': 1, 'X': 10}
+    assert split_params(" P0 S1 X10") == {"P": 0, "S": 1, "X": 10}
 
 
 def test_split_float_params():
-    assert split_params(' P0.1 S1.1345 X10.0') == {'P': 0.1, 'S': 1.1345, 'X': 10.0}
+    assert split_params(" P0.1 S1.1345 X10.0") == {"P": 0.1, "S": 1.1345, "X": 10.0}
 
 
 def test_split_sub1_params():
-    assert split_params(' P0.00001 S-0.00021 X.0001 Y-.003213') == {'P': 0.00001, 'S': -0.00021, 'X': 0.0001, 'Y': -0.003213}
+    assert split_params(" P0.00001 S-0.00021 X.0001 Y-.003213") == {
+        "P": 0.00001,
+        "S": -0.00021,
+        "X": 0.0001,
+        "Y": -0.003213,
+    }
 
 
 def test_split_string_params():
-    assert split_params(' P"string"') == {'P': '"string"'}
+    assert split_params(' P"string"') == {"P": '"string"'}
 
 
 def test_split_string_with_semicolon_params():
-    assert split_params(' P"string ; semicolon"') == {'P': '"string ; semicolon"'}
+    assert split_params(' P"string ; semicolon"') == {"P": '"string ; semicolon"'}
 
 
 def test_split_neg_int_params():
-    assert split_params(' P-0 S-1 X-10') == {'P': 0, 'S': -1, 'X': -10}
+    assert split_params(" P-0 S-1 X-10") == {"P": 0, "S": -1, "X": -10}
 
 
 def test_split_neg_float_params():
-    assert split_params(' P-0.1 S-1.1345 X-10.0') == {'P': -0.1, 'S': -1.1345, 'X': -10.0}
+    assert split_params(" P-0.1 S-1.1345 X-10.0") == {
+        "P": -0.1,
+        "S": -1.1345,
+        "X": -10.0,
+    }
 
 
 def test_split_ip_params():
-    assert split_params('P192.168.0.1 S1') == {'P': '192.168.0.1', 'S': 1}
+    assert split_params("P192.168.0.1 S1") == {"P": "192.168.0.1", "S": 1}
 
 
 def test_split_no_space_params():
-    assert split_params('P0.1S1.1345X10.0A"string"') == {'P': 0.1, 'S': 1.1345, 'X': 10.0, 'A': '"string"'}
+    assert split_params('P0.1S1.1345X10.0A"string"') == {
+        "P": 0.1,
+        "S": 1.1345,
+        "X": 10.0,
+        "A": '"string"',
+    }
+
 
 def test_split_no_value_params():
-    assert split_params(' X') == {'X': True}
+    assert split_params(" X") == {"X": True}
+
 
 def test_split_multi_no_value_params():
-    assert split_params(' XYZ') == {'X': True, 'Y': True, 'Z': True}
+    assert split_params(" XYZ") == {"X": True, "Y": True, "Z": True}
+
 
 def test_split_multi_no_value_spaced_params():
-    assert split_params(' X Y Z') == {'X': True, 'Y': True, 'Z': True}
+    assert split_params(" X Y Z") == {"X": True, "Y": True, "Z": True}


### PR DESCRIPTION
Changed `get_lines` to generator for higher speed on heavier files and other changes made by code formatter Black

from 

```python
def get_lines(gcode, include_comments=False):
    .....
    lines = []
    for line in regex_lines:
        ....
        lines.append(
            GcodeLine(
                 command=command,
                 params=params,
                 comment=comment.strip(),
            ))

    return lines
```

to

```python
def get_lines(gcode, include_comments=False):
    .....
    for line in regex_lines:
        ....
        yield GcodeLine(
            command=command,
            params=params,
            comment=comment.strip(),
        )
```