### PR TITLE
'split_params' now handles parameter values prefixed with a '+' sign.

### DIFF
--- a/gcodeparser/gcode_parser.py
+++ b/gcodeparser/gcode_parser.py
@@ -76,7 +76,7 @@ class GcodeParser:
 
 
 def get_lines(gcode, include_comments=False):
-    regex = r'(?!; *.+)(G|M|T|g|m|t)(\d+)(([ \t]*(?!G|M|g|m)\w(".*"|([-\d\.]*)))*)[ \t]*(;[ \t]*(.*))?|;[ \t]*(.+)'
+    regex = r'(?!; *.+)(G|M|T|g|m|t)(\d+)(([ \t]*(?!G|M|g|m)\w(".*"|([-+\d\.]*)))*)[ \t]*(;[ \t]*(.*))?|;[ \t]*(.+)'
     regex_lines = re.findall(regex, gcode)
     lines = []
     for line in regex_lines:

--- a/gcodeparser/gcode_parser.py
+++ b/gcodeparser/gcode_parser.py
@@ -114,7 +114,7 @@ def element_type(element: str):
 
 
 def split_params(line):
-    regex = r'((?!\d)\w+?)(".*"|(\d+\.?)+|-?\d*\.?\d*)'
+    regex = r'((?!\d)\w+?)(".*"|(\d+\.?)+|[-+]?\d*\.?\d*)'
     elements = re.findall(regex, line)
     params = {}
     for element in elements:

--- a/test/test_get_lines.py
+++ b/test/test_get_lines.py
@@ -26,6 +26,15 @@ def test_params():
     assert get_lines('G1 X10 Y20')[0] == line
 
 
+def test_params_with_explicit_positive_values():
+    line = GcodeLine(
+        command=('G', 1),
+        params={'X': 10, 'Y': 20},
+        comment='',
+    )
+    assert get_lines('G1 X+10 Y+20')[0] == line
+
+
 def test_2_commands_line():
     line1 = GcodeLine(
         command=('G', 91),

--- a/test/test_split_params.py
+++ b/test/test_split_params.py
@@ -31,9 +31,15 @@ def test_split_string_with_semicolon_params():
 def test_split_neg_int_params():
     assert split_params(' P-0 S-1 X-10') == {'P': 0, 'S': -1, 'X': -10}
 
+def test_split_positive_int_params():
+    assert split_params(' P+0 S+1 X+10') == {'P': 0, 'S': 1, 'X': 10}
+
 
 def test_split_neg_float_params():
     assert split_params(' P-0.1 S-1.1345 X-10.0') == {'P': -0.1, 'S': -1.1345, 'X': -10.0}
+
+def test_split_positive_float_params():
+    assert split_params(' P+0.1 S+1.1345 X+10.0') == {'P': 0.1, 'S': 1.1345, 'X': 10.0}
 
 
 def test_split_ip_params():


### PR DESCRIPTION
Some tools, like Mainsail, send movement commands with an explicit '+' sign for some of the parameter values. This was not supported by the 'split_params' method.