### PR TITLE
restrict floats in gcode_str() to 4 decimal places

### DIFF
--- a/gcodeparser/__init__.py
+++ b/gcodeparser/__init__.py
@@ -106,6 +106,8 @@ class GcodeLine:
             is_flag_parameter = value is True
             if is_flag_parameter:
                 return ""
+            if type(value) is float:
+                return f"{value:{'.4f'}}".rstrip("0").rstrip(".")
             return str(value)
 
         params = " ".join(f"{param}{param_value(param)}" for param in self.params.keys())


### PR DESCRIPTION
In gcode_str() restrict floats to 4 decimal places and strip redundant zeros/decimal point.